### PR TITLE
Add Python version

### DIFF
--- a/qc.py
+++ b/qc.py
@@ -108,10 +108,11 @@ def statevcector_normalization():
 
 def results():
     print("results:")
+    graphchar = '\N{Black Circle}'
     b = 0
     # evens then odds
     for n in chain(range(0, qc.COUNT, 2), range(1, qc.COUNT, 2)):
-        print(f'{b:02b}: [{qc.z[n]}] {qc.z[n] * "Q"}')
+        print(f'{b:02b}: [{qc.z[n]}] {qc.z[n] * graphchar}')
         b += 1
 
 def main():

--- a/qc.py
+++ b/qc.py
@@ -5,13 +5,17 @@
 import os
 from math import sqrt
 from random import random
+from itertools import chain
 
 class QC:
+    # naively provide a place to store stuff
+    COUNT = 4
     real = [1, 0, 0, 0]
     imaginary = [0, 0, 0, 0]
     z = [0, 0, 0, 0]
     p = [0, 0, 0, 0]
     a = [0, 0]
+    b = [0, 0]
     sq = 0
 
 qc = QC()
@@ -29,7 +33,8 @@ class Clear:
 
 clear = Clear()
 
-def simulate(gate):
+def simulate_OLD(gate):
+    # a dispatch would be more concise
     match gate:
         case "x0":
             x0()
@@ -52,7 +57,12 @@ def simulate(gate):
         case "sw":
             sw()
 
-# 400
+def simulate(gate):
+    # use a dispatch table to select function to run
+    gates = (x0, x1, y0, y1, z0, z1, h0, h1, cx, sw)
+    funcs = {g.__name__: g for g in gates}
+    funcs[gate]()
+
 def x0():
     qc.a[0] = qc.real[0]; qc.real[0] = qc.real[1]; qc.real[1] = qc.a[0]
     qc.a[0] = qc.imaginary[0]; qc.imaginary[0] = qc.imaginary[1]; qc.imaginary[1] = qc.a[0]
@@ -60,15 +70,11 @@ def x0():
     qc.a[0] = qc.imaginary[2]; qc.imaginary[2] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
     return
 
-# 440
 def y0():
-    qc.a[0] = qc.imaginary[0]; qc.imaginary[0] = -qc.real[0]; qc.real[0] = qc.a[0]
-    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = -qc.real[1]; qc.real[1] = qc.a[0]
-    qc.a[0] = qc.imaginary[2]; qc.imaginary[2] = -qc.real[2]; qc.real[2] = qc.a[0]
-    qc.a[0] = qc.imaginary[3]; qc.imaginary[3] = -qc.real[3]; qc.real[3] = qc.a[0]
+    for n in range(qc.COUNT):
+        qc.a[0] = qc.imaginary[n]; qc.imaginary[n] = -qc.real[n]; qc.real[n] = qc.a[0]
     return
 
-# 420
 def x1():
     qc.a[0] = qc.real[1]; qc.real[1] = qc.real[3]; qc.real[3] = qc.a[0]
     qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
@@ -77,80 +83,63 @@ def x1():
     y0() # "fall through"? https://github.com/dakk/qc64/issues/5
     return
 
-# 460
 def y1():
     qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = -qc.real[1]; qc.real[1] = qc.a[0]
     qc.a[0] = qc.imaginary[3]; qc.imaginary[3] = -qc.real[3]; qc.real[3] = qc.a[0]
     return
 
-# 480
 def z0():
     qc.imaginary[2] = -qc.imaginary[2]; qc.imaginary[3] = -qc.imaginary[3]
     return
 
-# 500
 def z1():
     qc.imaginary[1] = -qc.imaginary[1]; qc.imaginary[3] = -qc.imaginary[3]
     return
 
-# 520
 def h0():
     qc.a[0] = (qc.real[0] + qc.real[1]) / sqrt(2); qc.a[1] = (qc.imaginary[0] + qc.imaginary[1]) / sqrt(2)
-    b0 = (qc.real[0] - qc.real[1]) / sqrt(2); b1 = (qc.imaginary[0] - qc.imaginary[1]) / sqrt(2)
-    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[1] = b0; qc.imaginary[1] = b1
+    qc.b[0] = (qc.real[0] - qc.real[1]) / sqrt(2); qc.b[1] = (qc.imaginary[0] - qc.imaginary[1]) / sqrt(2)
+    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[1] = qc.b[0]; qc.imaginary[1] = qc.b[1]
     qc.a[0] = (qc.real[2] + qc.real[3]) / sqrt(2); qc.a[1] = (qc.imaginary[2] + qc.imaginary[3]) / sqrt(2)
-    b0 = (qc.real[2] - qc.real[3]) / sqrt(2); b1 = (qc.imaginary[2] - qc.imaginary[3]) / sqrt(2)
-    qc.real[2] = qc.a[0]; qc.imaginary[2] = qc.a[1]; qc.real[3] = b0; qc.imaginary[3] = b1
+    qc.b[0] = (qc.real[2] - qc.real[3]) / sqrt(2); qc.b[1] = (qc.imaginary[2] - qc.imaginary[3]) / sqrt(2)
+    qc.real[2] = qc.a[0]; qc.imaginary[2] = qc.a[1]; qc.real[3] = qc.b[0]; qc.imaginary[3] = qc.b[1]
     return
 
-# 540
 def h1():
     qc.a[0] = (qc.real[0] + qc.real[2]) / sqrt(2); qc.a[1] = (qc.imaginary[0] + qc.imaginary[2]) / sqrt(2)
-    b0 = (qc.real[0] - qc.real[2]) / sqrt(2); b1 = (qc.imaginary[0] - qc.imaginary[2]) / sqrt(2)
-    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[2] = b0; qc.imaginary[2] = b1
+    qc.b[0] = (qc.real[0] - qc.real[2]) / sqrt(2); qc.b[1] = (qc.imaginary[0] - qc.imaginary[2]) / sqrt(2)
+    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[2] = qc.b[0]; qc.imaginary[2] = qc.b[1]
     qc.a[0] = (qc.real[1] + qc.real[3]) / sqrt(2); qc.a[1] = (qc.imaginary[1] + qc.imaginary[3]) / sqrt(2)
-    b0 = (qc.real[1] - qc.real[3]) / sqrt(2); b1 = (qc.imaginary[1] - qc.imaginary[3]) / sqrt(2)
-    qc.real[1] = qc.a[0]; qc.imaginary[1] = qc.a[1]; qc.real[3] = b0; qc.imaginary[3] = b1
+    qc.b[0] = (qc.real[1] - qc.real[3]) / sqrt(2); qc.b[1] = (qc.imaginary[1] - qc.imaginary[3]) / sqrt(2)
+    qc.real[1] = qc.a[0]; qc.imaginary[1] = qc.a[1]; qc.real[3] = qc.b[0]; qc.imaginary[3] = qc.b[1]
     return
 
-# 560
 def cx():
     qc.a[0] = qc.real[1]; qc.real[1] = qc.real[3]; qc.real[3] = qc.a[0]
     qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
     return 
 
-# 580
 def sw():
     qc.a[0] = qc.real[1]; qc.real[1] = qc.real[2]; qc.real[2] = qc.a[0]
     qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[2]; qc.imaginary[2] = qc.a[0]
     return
 
-# 600
 def statevcector_normalization():
     nf = sqrt(1 / qc.sq)
-    qc.real[0] = qc.real[0] * nf
-    qc.imaginary[0] = qc.imaginary[0] * nf
-    qc.real[1] = qc.real[1] * nf
-    qc.imaginary[1] = qc.imaginary[1] * nf
-    qc.real[2] = qc.real[2] * nf
-    qc.imaginary[2] = qc.imaginary[2] * nf
-    qc.real[3] = qc.real[3] * nf
-    qc.imaginary[3] = qc.imaginary[3] * nf
+    for n in range(qc.COUNT):
+        qc.real[n] *= nf
+        qc.imaginary[n] *= nf
     return
 
 def results():
     print("results:")
-    print(f'00: [{qc.z[0]}] {qc.z[0] * "Q"}')
-    print(f'01: [{qc.z[2]}] {qc.z[2] * "Q"}')
-    print(f'10: [{qc.z[1]}] {qc.z[1] * "Q"}')
-    print(f'11: [{qc.z[3]}] {qc.z[3] * "Q"}')
+    b = 0
+    # evens then odds
+    for n in chain(range(0, qc.COUNT, 2), range(1, qc.COUNT, 2)):
+        print(f'{b:02b}: [{qc.z[n]}] {qc.z[n] * "Q"}')
+        b += 1
 
 def main():
-    '''
-    qc.real[0] = 1; qc.imaginary[0] = 0; qc.real[1] = 0; qc.imaginary[1] = 0
-    qc.real[2] = 0; qc.imaginary[2] = 0; qc.real[3] = 0; qc.imaginary[3] = 0
-    qc.a[0] = 0
-    '''
     shots = 28
     clear()
     print("quantum simulator")
@@ -164,22 +153,23 @@ def main():
         print(".", end = '')
     print()
 
-    qc.sq = qc.real[0]*qc.real[0] + qc.imaginary[0]*qc.imaginary[0] + qc.real[1]*qc.real[1] + qc.imaginary[1]*qc.imaginary[1] + qc.real[2]*qc.real[2] + qc.imaginary[2]*qc.imaginary[2] + qc.real[3]*qc.real[3] + qc.imaginary[3]*qc.imaginary[3]
+    qc.sq = sum([x ** 2 for x in qc.real] +
+                [x ** 2 for x in qc.imaginary])
+
     if abs(qc.sq - 1) > 0.00001: statevcector_normalization()
 
     print(f"running {shots} iterations...")
-    # qc.z[0] = 0; qc.z[1] = 0; qc.z[2] = 0; qc.z[3] = 0
-    qc.p[0] = (qc.real[0] * qc.real[0] + qc.imaginary[0] * qc.imaginary[0])
-    qc.p[1] = (qc.real[1] * qc.real[1] + qc.imaginary[1] * qc.imaginary[1]) + qc.p[0]
-    qc.p[2] = (qc.real[2] * qc.real[2] + qc.imaginary[2] * qc.imaginary[2]) + qc.p[1]
-    qc.p[3] = (qc.real[3] * qc.real[3] + qc.imaginary[3] * qc.imaginary[3]) + qc.p[2]
+    prev = 0
+    for n in range(qc.COUNT):
+        qc.p[n] = qc.real[n] ** 2 + qc.imaginary[n] ** 2 + prev
+        prev = qc.p[n]
 
     for i in range(shots):
         r = random()
-        if r < qc.p[0]: qc.z[0] = qc.z[0] + 1
-        if r >= qc.p[0] and r < qc.p[1]: qc.z[1] = qc.z[1] + 1
-        if r >= qc.p[1] and r < qc.p[2]: qc.z[2] = qc.z[2] + 1
-        if r >= qc.p[2] and r < qc.p[3]: qc.z[3] = qc.z[3] + 1
+        if r < qc.p[0]: qc.z[0] += 1
+        elif r >= qc.p[0] and r < qc.p[1]: qc.z[1] += 1
+        elif r >= qc.p[1] and r < qc.p[2]: qc.z[2] += 1
+        elif r >= qc.p[2] and r < qc.p[3]: qc.z[3] += 1
 
 if __name__ == '__main__':
     main()

--- a/qc.py
+++ b/qc.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# requires Python >= 3.10
+# based on https://github.com/dakk/qc64
+
+import os
+from math import sqrt
+from random import random
+
+class QC:
+    real = [1, 0, 0, 0]
+    imaginary = [0, 0, 0, 0]
+    z = [0, 0, 0, 0]
+    p = [0, 0, 0, 0]
+    a = [0, 0]
+    sq = 0
+
+qc = QC()
+
+# from https://stackoverflow.com/a/11526998
+# https://docs.python.org/3/library/os.html#os.name doesn't include ce or dos, so ???
+class Clear:
+   def __call__(self):
+      if os.name in ('ce', 'nt', 'dos'): os.system('cls')
+      elif os.name == 'posix': os.system('clear')
+      else: print('\n' * os.get_terminal_size().lines, end = '')
+   def __neg__(self): self()
+   def __repr__(self):
+      self(); return ''
+
+clear = Clear()
+
+def simulate(gate):
+    match gate:
+        case "x0":
+            x0()
+        case "x1":
+            x1()
+        case "y0":
+            y0()
+        case "y1":
+            y1()
+        case "z0":
+            z0()
+        case "z1":
+            z1()
+        case "h0":
+            h0()
+        case "h1":
+            h1()
+        case "cx":
+            cx()
+        case "sw":
+            sw()
+
+# 400
+def x0():
+    qc.a[0] = qc.real[0]; qc.real[0] = qc.real[1]; qc.real[1] = qc.a[0]
+    qc.a[0] = qc.imaginary[0]; qc.imaginary[0] = qc.imaginary[1]; qc.imaginary[1] = qc.a[0]
+    qc.a[0] = qc.real[2]; qc.real[2] = qc.real[3]; qc.real[3] = qc.a[0]
+    qc.a[0] = qc.imaginary[2]; qc.imaginary[2] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
+    return
+
+# 440
+def y0():
+    qc.a[0] = qc.imaginary[0]; qc.imaginary[0] = -qc.real[0]; qc.real[0] = qc.a[0]
+    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = -qc.real[1]; qc.real[1] = qc.a[0]
+    qc.a[0] = qc.imaginary[2]; qc.imaginary[2] = -qc.real[2]; qc.real[2] = qc.a[0]
+    qc.a[0] = qc.imaginary[3]; qc.imaginary[3] = -qc.real[3]; qc.real[3] = qc.a[0]
+    return
+
+# 420
+def x1():
+    qc.a[0] = qc.real[1]; qc.real[1] = qc.real[3]; qc.real[3] = qc.a[0]
+    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
+    qc.a[0] = qc.real[0]; qc.real[0] = qc.real[2]; qc.real[2] = qc.a[0]
+    qc.a[0] = qc.imaginary[0]; qc.imaginary[0] = qc.imaginary[2]; qc.imaginary[2] = qc.a[0]
+    y0() # "fall through"? https://github.com/dakk/qc64/issues/5
+    return
+
+# 460
+def y1():
+    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = -qc.real[1]; qc.real[1] = qc.a[0]
+    qc.a[0] = qc.imaginary[3]; qc.imaginary[3] = -qc.real[3]; qc.real[3] = qc.a[0]
+    return
+
+# 480
+def z0():
+    qc.imaginary[2] = -qc.imaginary[2]; qc.imaginary[3] = -qc.imaginary[3]
+    return
+
+# 500
+def z1():
+    qc.imaginary[1] = -qc.imaginary[1]; qc.imaginary[3] = -qc.imaginary[3]
+    return
+
+# 520
+def h0():
+    qc.a[0] = (qc.real[0] + qc.real[1]) / sqrt(2); qc.a[1] = (qc.imaginary[0] + qc.imaginary[1]) / sqrt(2)
+    b0 = (qc.real[0] - qc.real[1]) / sqrt(2); b1 = (qc.imaginary[0] - qc.imaginary[1]) / sqrt(2)
+    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[1] = b0; qc.imaginary[1] = b1
+    qc.a[0] = (qc.real[2] + qc.real[3]) / sqrt(2); qc.a[1] = (qc.imaginary[2] + qc.imaginary[3]) / sqrt(2)
+    b0 = (qc.real[2] - qc.real[3]) / sqrt(2); b1 = (qc.imaginary[2] - qc.imaginary[3]) / sqrt(2)
+    qc.real[2] = qc.a[0]; qc.imaginary[2] = qc.a[1]; qc.real[3] = b0; qc.imaginary[3] = b1
+    return
+
+# 540
+def h1():
+    qc.a[0] = (qc.real[0] + qc.real[2]) / sqrt(2); qc.a[1] = (qc.imaginary[0] + qc.imaginary[2]) / sqrt(2)
+    b0 = (qc.real[0] - qc.real[2]) / sqrt(2); b1 = (qc.imaginary[0] - qc.imaginary[2]) / sqrt(2)
+    qc.real[0] = qc.a[0]; qc.imaginary[0] = qc.a[1]; qc.real[2] = b0; qc.imaginary[2] = b1
+    qc.a[0] = (qc.real[1] + qc.real[3]) / sqrt(2); qc.a[1] = (qc.imaginary[1] + qc.imaginary[3]) / sqrt(2)
+    b0 = (qc.real[1] - qc.real[3]) / sqrt(2); b1 = (qc.imaginary[1] - qc.imaginary[3]) / sqrt(2)
+    qc.real[1] = qc.a[0]; qc.imaginary[1] = qc.a[1]; qc.real[3] = b0; qc.imaginary[3] = b1
+    return
+
+# 560
+def cx():
+    qc.a[0] = qc.real[1]; qc.real[1] = qc.real[3]; qc.real[3] = qc.a[0]
+    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[3]; qc.imaginary[3] = qc.a[0]
+    return 
+
+# 580
+def sw():
+    qc.a[0] = qc.real[1]; qc.real[1] = qc.real[2]; qc.real[2] = qc.a[0]
+    qc.a[0] = qc.imaginary[1]; qc.imaginary[1] = qc.imaginary[2]; qc.imaginary[2] = qc.a[0]
+    return
+
+# 600
+def statevcector_normalization():
+    nf = sqrt(1 / qc.sq)
+    qc.real[0] = qc.real[0] * nf
+    qc.imaginary[0] = qc.imaginary[0] * nf
+    qc.real[1] = qc.real[1] * nf
+    qc.imaginary[1] = qc.imaginary[1] * nf
+    qc.real[2] = qc.real[2] * nf
+    qc.imaginary[2] = qc.imaginary[2] * nf
+    qc.real[3] = qc.real[3] * nf
+    qc.imaginary[3] = qc.imaginary[3] * nf
+    return
+
+def results():
+    print("results:")
+    print(f'00: [{qc.z[0]}] {qc.z[0] * "Q"}')
+    print(f'01: [{qc.z[2]}] {qc.z[2] * "Q"}')
+    print(f'10: [{qc.z[1]}] {qc.z[1] * "Q"}')
+    print(f'11: [{qc.z[3]}] {qc.z[3] * "Q"}')
+
+def main():
+    '''
+    qc.real[0] = 1; qc.imaginary[0] = 0; qc.real[1] = 0; qc.imaginary[1] = 0
+    qc.real[2] = 0; qc.imaginary[2] = 0; qc.real[3] = 0; qc.imaginary[3] = 0
+    qc.a[0] = 0
+    '''
+    shots = 28
+    clear()
+    print("quantum simulator")
+    print("created by davide gessa (dakk)")
+    print("enter gate seq (x0,x1,y0,y1,z0,z1,h0,h1,cx,sw)")
+    g = input()
+    print("calculating the statevector...", end = '')
+    for i in range(0, len(g), 2):
+        gate = g[i:i + 2]
+        simulate(gate)
+        print(".", end = '')
+    print()
+
+    qc.sq = qc.real[0]*qc.real[0] + qc.imaginary[0]*qc.imaginary[0] + qc.real[1]*qc.real[1] + qc.imaginary[1]*qc.imaginary[1] + qc.real[2]*qc.real[2] + qc.imaginary[2]*qc.imaginary[2] + qc.real[3]*qc.real[3] + qc.imaginary[3]*qc.imaginary[3]
+    if abs(qc.sq - 1) > 0.00001: statevcector_normalization()
+
+    print(f"running {shots} iterations...")
+    # qc.z[0] = 0; qc.z[1] = 0; qc.z[2] = 0; qc.z[3] = 0
+    qc.p[0] = (qc.real[0] * qc.real[0] + qc.imaginary[0] * qc.imaginary[0])
+    qc.p[1] = (qc.real[1] * qc.real[1] + qc.imaginary[1] * qc.imaginary[1]) + qc.p[0]
+    qc.p[2] = (qc.real[2] * qc.real[2] + qc.imaginary[2] * qc.imaginary[2]) + qc.p[1]
+    qc.p[3] = (qc.real[3] * qc.real[3] + qc.imaginary[3] * qc.imaginary[3]) + qc.p[2]
+
+    for i in range(shots):
+        r = random()
+        if r < qc.p[0]: qc.z[0] = qc.z[0] + 1
+        if r >= qc.p[0] and r < qc.p[1]: qc.z[1] = qc.z[1] + 1
+        if r >= qc.p[1] and r < qc.p[2]: qc.z[2] = qc.z[2] + 1
+        if r >= qc.p[2] and r < qc.p[3]: qc.z[3] = qc.z[3] + 1
+
+if __name__ == '__main__':
+    main()
+    results()

--- a/qc.py
+++ b/qc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# requires Python >= 3.10
 # based on https://github.com/dakk/qc64
 
 import os
@@ -32,30 +31,6 @@ class Clear:
       self(); return ''
 
 clear = Clear()
-
-def simulate_OLD(gate):
-    # a dispatch would be more concise
-    match gate:
-        case "x0":
-            x0()
-        case "x1":
-            x1()
-        case "y0":
-            y0()
-        case "y1":
-            y1()
-        case "z0":
-            z0()
-        case "z1":
-            z1()
-        case "h0":
-            h0()
-        case "h1":
-            h1()
-        case "cx":
-            cx()
-        case "sw":
-            sw()
 
 def simulate(gate):
     # use a dispatch table to select function to run

--- a/qc.py
+++ b/qc.py
@@ -109,11 +109,9 @@ def statevcector_normalization():
 def results():
     print("results:")
     graphchar = '\N{Black Circle}'
-    b = 0
     # evens then odds
     for n in chain(range(0, qc.COUNT, 2), range(1, qc.COUNT, 2)):
-        print(f'{b:02b}: [{qc.z[n]}] {qc.z[n] * graphchar}')
-        b += 1
+        print(f'{n:02b}: [{qc.z[n]}] {qc.z[n] * graphchar}')
 
 def main():
     shots = 28


### PR DESCRIPTION
This is a fairly straightforward port to Python made without knowledge of how the simulator works. It has nothing to do with the Commodore 64, but provides a variant of the code that may prove valuable to some. It provides some contrast to the limitations present in a 40+ year old dialect of BASIC.

More detailed variable and function names could be a next step. The functions that perform swaps could use some work. There's probably plenty of other room for improvement.

I implemented the fall-through discussed in issue #5 but if that's changed, the call to `y0` can be removed from `x1`.